### PR TITLE
add handlers to catch validation errors (specifically arrays)

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -77,10 +77,22 @@ module.exports.validateAttribute = function (key, validationRules, validationMod
         var result;
 
         if (doSingleCheck) {
-            result = validator.fn.call(context, key, submittedValue, validator);
+            try {
+                result = validator.fn.call(context, key, submittedValue, validator);
+            }
+            catch (err) {
+                result = true;
+            }
         } else if (!doSingleCheck) {
             var invalidValue = _.find(submittedValue, function(currentValue) {
-                return validator.fn.call(context, key, currentValue, validator);
+                var returnVal;
+                try {
+                    returnVal = validator.fn.call(context, key, currentValue, validator);
+                }
+                catch (err) {
+                    returnVal = true;
+                }
+                return returnVal;
             });
 
             if (!_.isUndefined(invalidValue)) {

--- a/test/validator_integration_test.js
+++ b/test/validator_integration_test.js
@@ -88,4 +88,8 @@ describe('Validators', function () {
         test('isBefore', '2011-08-04', '2011-08-03', '2011-08-04');
         test('isAfter', '2011-08-04', '2011-08-05', '2011-08-04');
     });
+
+    it('node-validator arrays', function() {
+        test('isInt', true, '123', [['456', '0.123']]);
+    });
 });


### PR DESCRIPTION
If I had an "isInt" validator in my route, but the request came through as an array, the request would hang and eventually time out/500. For example, I had a 

``` coffeescript
    server.get
        url: "/posts"
        swagger:
            summary: "Get posts"
            notes: "..."
            nickname: "Get posts"
        validation:
            before:
                isRequired: false
                isInt: true
                scope: "query"
```

When called with `/posts?before=12345&before=123456`, the server would hang. This should address that issue, although I didn't add a ton of test cases...
