### PR TITLE
include files in possible validation scopes

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -27,7 +27,8 @@ var seperatorChar = module.exports._speratorChar = '.';
 var internalToExternalScope = {
     resources: 'params',
     queries: 'query',
-    content: 'body'
+    content: 'body',
+    files: 'files'
 };
 
 var hasValue = module.exports.hasValue = function(value) {


### PR DESCRIPTION
Includes "files", which corresponds to `req.files`, alongside "content", "queries", and "resources".