### PR TITLE
next() call on validation error

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -45,13 +45,15 @@ function parseErrorMessage(errors, template) {
 
 module.exports.handle = function (errors, req, res, options, next) {
     if (options.handleError) {
-        return options.handleError(res, errors);
+        return options.handleError(res, errors, next);
     } else if (options.errorHandler) {
-        return res.send(new options.errorHandler(parseErrorMessage(errors, options.template)));
+        res.send(new options.errorHandler(parseErrorMessage(errors, options.template)));
+        return next(false);
     } else {
-        return res.send (400, {
+        res.send (400, {
             status: 'validation failed',
             errors: errors
         });
+        return next(false);
     }
 };

--- a/test/units/errors_test.js
+++ b/test/units/errors_test.js
@@ -48,7 +48,7 @@ describe('Errors', function () {
 
         index.error.handle(errors, null, res, {errorHandler: errorHandler}, next);
 
-        next.called.should.not.be.ok;
+        next.calledWith(false).should.be.ok;
         send.calledWith({
             code: 'InvalidArgument',
             message: 'dummy (MISSING): Field is required'
@@ -66,7 +66,7 @@ describe('Errors', function () {
 
         index.error.handle(errors, null, res, {}, next);
 
-        next.called.should.not.be.ok;
+        next.calledWith(false).should.be.ok;
         send.calledWith(400, {
             status: 'validation failed',
             errors: errors
@@ -84,7 +84,7 @@ describe('Errors', function () {
 
         index.error.handle(errors, null, res, {}, next);
 
-        next.called.should.not.be.ok;
+        next.calledWith(false).should.be.ok;
         send.calledWith(400, {
             status: 'validation failed',
             errors: errors


### PR DESCRIPTION
I've mentioned that validation handler doesn't make `next()` call on error. As a result, restify doesn't run all following post-request handlers (e.g. loggers attached via `server.on('after', ...);`).
More restify-friendly solution was proposed in the PR.