### PR TITLE
Fixed unit tests and major bug concerning query-string validation

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License
  *
  * Copyright 2014 Timo Behrmann, Guillaume Chauvet.
@@ -76,8 +76,7 @@ module.exports.validateAttribute = function (key, validationRules, validationMod
     var validatorChain = this.getValidatorChain(key, validationRules, validationModel, scope, req, options, recentErrors);
     var self = this;
 
-    scope = req.params ? 'params' : scope;
-    var submittedValue = req[scope] !== undefined ? req[scope][key] : undefined;
+    var submittedValue = typeof req[scope] === 'function' ? req[scope]() : req[scope] !== undefined ? req[scope][key] : undefined;
     var supportsMultipleValues = validationRules.multiple === true;
     var isArray = _.isArray(submittedValue);
     var doSingleCheck = !(isArray && supportsMultipleValues);
@@ -131,8 +130,6 @@ module.exports.validateAttribute = function (key, validationRules, validationMod
 
 function _createError(scope, key, validator) {
     var error = {
-        //scope: utils.getInternalScope(scope),
-        //field: key,
         type: validatorCodes.codes[validator.name] || validatorCodes.codes._default
     };
 

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "node-restify-validation",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "author": {
     "name": "Timo Behrmann"
   },
   "contributors": [
     "Marcos Sanz",
-    "Guillaume Chauvet"
+    "Guillaume Chauvet",
+    "Stefan Schärmeli"
   ],
   "license": "MIT",
   "keywords": [
@@ -29,7 +30,7 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "lodash": "^2.4.1",
-    "validator": "3.7.x"
+    "validator": "3.22.x"
   },
   "devDependencies": {
     "restify": ">=2.8.1",

--- a/test/integrations/restify_test.js
+++ b/test/integrations/restify_test.js
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License
  *
  * Copyright 2015 Timo Behrmann, Guillaume Chauvet
@@ -27,125 +27,140 @@ var restify = require('restify');
 var validationParser = require('../../lib').validationPlugin;
 var request = require('supertest');
 
-describe("[INTEGRATION][RESTIFY]", function () {
+describe("[INTEGRATION][RESTIFY]", function() {
 
-    describe('ISSUES', function() {
-      
-      describe('#32', function() {
-  
-	var server;
-	
-	before(function (done) {
-	    server = restify.createServer();
-	    server.use(restify.bodyParser({mapParams: false}));
-	    server.use(validationParser({
-	      forbidUndefinedVariables: true
-	    }));
-	    server.listen(0, function() {
-		server.post({
-		  url: '/foo/:id',
-		  validation: {
-		    resources: {
-			id: { isRequired: true, 'swaggerScope': 'path' }
-		    },
-		    content: {
-			name: { isRequired: false },
-			grades: { isRequired: false },
-			school: { isRequired: false },
-			subjectArea: { isRequired: false }
-		    }
-		  }
-		}, function (req, res, next) {
-		    res.send(req.body);
-		    next();
-		});
-		done();
-	    });
-	});
+  describe('ISSUES', function() {
 
-	after(function (done) {
-	    server.close(done);
-	});
+    describe('#32', function() {
 
-      
-	describe("on GET", function() {
-	
-	    it("not allowed route", function (done) {
-		request(server)
-		.get('/foo')
-		.expect(404)
-		.end(done);
-	    });
+      var server;
 
-	});
-	
-	describe("on POST", function() {
-	
-	    it("with 1 optional field", function (done) {
-		request(server)
-		.post('/foo/73')
-		.send({"name": "test"})
-		.expect(200, {"name": "test"})
-		.end(done);
-	    });
-
-	});
-
+      before(function(done) {
+        server = restify.createServer();
+        server.use(restify.bodyParser({
+          mapParams: false
+        }));
+        server.use(validationParser({
+          forbidUndefinedVariables: true
+        }));
+        server.listen(0, function() {
+          server.post({
+            url: '/foo/:id',
+            validation: {
+              resources: {
+                id: {
+                  isRequired: true,
+                  'swaggerScope': 'path'
+                }
+              },
+              content: {
+                name: {
+                  isRequired: false
+                },
+                grades: {
+                  isRequired: false
+                },
+                school: {
+                  isRequired: false
+                },
+                subjectArea: {
+                  isRequired: false
+                }
+              }
+            }
+          }, function(req, res, next) {
+            res.send(req.body);
+            next();
+          });
+          done();
+        });
       });
-      
-      describe('#37', function() {
-  
-	var server;
-	
-	before(function (done) {
-	    server = restify.createServer();
-	    server.use(restify.bodyParser({mapParams: false}));
-	    server.use(validationParser({
-	      mapParams: true
-	    }));
-	    server.use(restify.queryParser({mapParams: false}));
-	    server.listen(0, function() {
-		server.get({
-		  url: '/test/:name',
-		  validation: {
-		    queries: {
-		      age: {
-			isRequired: true
-		      }
-		    }
-		  }
-		}, function (req, res, next) {
-		    res.send(req.params);
-		    next();
-		});
-		done();
-	    });
-	});
 
-	after(function (done) {
-	    server.close(done);
-	});
+      after(function(done) {
+        server.close(done);
+      });
 
-      
-	describe("on GET", function() {
-	
-	    it("no route", function (done) {
-		request(server)
-		.get('/test')
-		.expect(404)
-		.end(done);
-	    });
-	    
-	    it("with undefined query", function (done) {
-		request(server)
-		.get('/test/foo')
-		.expect(400)
-		.end(done);
-	    });
 
-	});
+      describe("on GET", function() {
+        it("not allowed route", function(done) {
+          request(server)
+            .get('/foo')
+            .expect(404)
+            .end(done);
+        });
+      });
+
+      describe("on POST", function() {
+        it("with 1 optional field", function(done) {
+          request(server)
+            .post('/foo/73')
+            .send({
+              "name": "test"
+            })
+            .expect(200, {
+              "name": "test"
+            })
+            .end(done);
+        });
+      });
+    });
+
+    describe('#37', function() {
+
+      var server;
+      before(function(done) {
+        server = restify.createServer();
+        server.use(restify.bodyParser({ mapParams: false }));
+        server.use(validationParser({ mapParams: true }));
+        server.use(restify.queryParser({ mapParams: false }));
+        server.listen(0, function() {
+          server.get({
+            url: '/test/:name',
+            validation: {
+              queries: {
+                age: {
+                  isRequired: true
+                }
+              }
+            }
+          }, function(req, res, next) {
+            res.send(req.params);
+            next();
+          });
+          done();
+        });
+      });
+
+      after(function(done) {
+        server.close(done);
+      });
+
+      describe("on GET", function() {
+
+        it("no route", function(done) {
+          request(server)
+            .get('/test')
+            .expect(404)
+            .end(done);
+        });
+
+        it("with undefined query", function(done) {
+          request(server)
+            .get('/test/foo')
+            .expect(409)
+            .end(done);
+        });
+
+        it("with query present", function(done) {
+          request(server)
+            .get('/test/foo?age=1')
+            .expect(200)
+            .end(done);
+        });
 
       });
 
     });
+
+  });
 });

--- a/test/integrations/validator_test.js
+++ b/test/integrations/validator_test.js
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License
  *
  * Copyright 2014 Timo Behrmann, Guillaume Chauvet.
@@ -27,36 +27,38 @@ var index = require('../../lib/index');
 
 
 var test = function (validatorName, validatorValue, correctValue, incorrectValue) {
-    var validationReq = { params: { }, query: {} };
+    var validationReq = { query: {} };
     var validationModel = { queries: { myParameter: { isRequired: true } } };
     var options = { errorsAsArray: true };
 
     validationModel.queries.myParameter[validatorName] = validatorValue;
-    var errors0 = index.validation.process(validationModel, validationReq, options);
-    errors0.length.should.equal(1);
-    errors0[0].should.exist;
-    errors0[0].field.should.equal('myParameter');
-    errors0[0].code.should.equal('MISSING');
 
+    //check MISSING validation
+    var checkMissing = index.validation.process(validationModel, validationReq, options);
+    checkMissing.length.should.equal(1);
+    checkMissing[0].type.should.equal('MISSING');
+
+    // check VALID validation
     if (!_.isArray(correctValue)) {
         correctValue = [correctValue];
     }
+
     _.each(correctValue, function(value) {
         validationReq.query.myParameter = value;
-        var errors1 = index.validation.process(validationModel, validationReq, options);
-        errors1.length.should.equal(0);
+        var checkValid = index.validation.process(validationModel, validationReq, options);
+        checkValid.length.should.equal(0);
     });
 
+    // check INVALID validation
     if (!_.isArray(incorrectValue)) {
         incorrectValue = [incorrectValue];
     }
 
     _.each(incorrectValue, function(value) {
         validationReq.query.myParameter = value;
-        var errors2 = index.validation.process(validationModel, validationReq, options);
-        errors2.length.should.equal(1);
-        errors2[0].field.should.equal('myParameter');
-        errors2[0].code.should.equal('INVALID');
+        var checkInvalid = index.validation.process(validationModel, validationReq, options);
+        checkInvalid.length.should.equal(1);
+        checkInvalid[0].type.should.equal('INVALID');
     });
 };
 

--- a/test/units/condition_test.js
+++ b/test/units/condition_test.js
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License
  *
  * Copyright 2014 Timo Behrmann, Guillaume Chauvet.
@@ -33,20 +33,17 @@ describe('Conditions', function () {
             }
         };
 
-        var errors = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
-        errors.length.should.equal(1);
-        errors[0].scope.should.equal('resources');
-        errors[0].field.should.equal('b');
-        errors[0].code.should.equal('MISSING');
-
+        var missingErrors = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
+        missingErrors.length.should.equal(1);
+        missingErrors[0].type.should.equal('MISSING');
 
         validationReq.params.b = 'test';
-        var errors2 = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
-        errors2.length.should.equal(0);
+        var presentErrors = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
+        presentErrors.length.should.equal(0);
 
-        validationReq.resources = {};
-        var errors3 = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
-        errors3.length.should.equal(0);
+        validationReq.params = {};
+        var notRequiredErrors = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
+        notRequiredErrors.length.should.equal(0);
 
         done();
     });
@@ -62,10 +59,7 @@ describe('Conditions', function () {
 
         var errors = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
         errors.length.should.equal(1);
-        errors[0].scope.should.equal('resources');
-        errors[0].field.should.equal('b');
-        errors[0].code.should.equal('MISSING');
-
+        errors[0].type.should.equal('MISSING');
 
         validationModel = {
             resources: {
@@ -76,9 +70,7 @@ describe('Conditions', function () {
 
         errors = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
         errors.length.should.equal(1);
-        errors[0].scope.should.equal('resources');
-        errors[0].field.should.equal('b');
-        errors[0].code.should.equal('MISSING');
+        errors[0].type.should.equal('MISSING');
 
         validationModel = {
             resources: {
@@ -102,7 +94,7 @@ describe('Conditions', function () {
 
         errors = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
         errors.length.should.equal(0);
-        
+
         done();
     });
 });

--- a/test/units/errors_test.js
+++ b/test/units/errors_test.js
@@ -57,7 +57,6 @@ describe('Errors', function () {
     });
 
     it('handle errors object', function (done) {
-
         var send = sinon.spy();
         var next = sinon.spy();
         var res = { send: send };
@@ -66,8 +65,9 @@ describe('Errors', function () {
         index.error.handle(errors, null, res, {}, next);
 
         next.calledWith(false).should.be.ok;
-        send.calledWith(400, {
-            status: 'validation failed',
+        send.calledWith(409, {
+            code: 'InvalidArgument',
+            message: 'Validation failed',
             errors: errors
         }).should.be.ok;
 
@@ -75,7 +75,6 @@ describe('Errors', function () {
     });
 
     it('handle errors array', function (done) {
-
         var send = sinon.spy();
         var next = sinon.spy();
         var res = { send: send };
@@ -84,8 +83,9 @@ describe('Errors', function () {
         index.error.handle(errors, null, res, {}, next);
 
         next.calledWith(false).should.be.ok;
-        send.calledWith(400, {
-            status: 'validation failed',
+        send.calledWith(409, {
+            code: 'InvalidArgument',
+            message: 'Validation failed',
             errors: errors
         }).should.be.ok;
 

--- a/test/units/validation_test.js
+++ b/test/units/validation_test.js
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License
  *
  * Copyright 2014 Timo Behrmann, Guillaume Chauvet.
@@ -240,25 +240,24 @@ describe('Validation', function () {
         it('errorsAsArray / errorsAsObject', function (done) {
             var validationReq = { params: { } };
             var validationModel = { resources: {
-                    status: { isRequired: true, isIn: ['foo', 'bar']}
+                    testParam: { isRequired: true, isIn: ['foo', 'bar']}
                 }
             };
 
-            var errors0 = index.validation.process(validationModel, validationReq, { errorsAsArray: false });
-            errors0.should.have.type('object');
-            errors0.status.should.exist;
-            errors0.status.field.should.equal('status');
-            errors0.status.code.should.equal('MISSING');
+            var objectRes = index.validation.process(validationModel, validationReq, { errorsAsArray: false });
+            objectRes.should.have.type('object');
+            objectRes.testParam.reason.should.equal('Field is required');
+            objectRes.testParam.type.should.equal('MISSING');
 
-            var errors1 = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
-            errors1.should.be.an.instanceof(Array);
-            errors1.length.should.equal(1);
-            errors1[0].field.should.equal('status');
-            errors1[0].code.should.equal('MISSING');
+            var arrayRes = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
+            arrayRes.should.be.an.instanceof(Array);
+            arrayRes.length.should.equal(1);
+            arrayRes[0].reason.should.equal('Field is required');
+            arrayRes[0].type.should.equal('MISSING');
 
             done();
         });
-        
+
         it('forbidUndefinedVariables', function (done) {
             var validationReq = { params: { foo: "foo", bar: "bar" } };
             var validationModel = { resources: {
@@ -266,16 +265,14 @@ describe('Validation', function () {
                 }
             };
 
-            var errors = index.validation.process(validationModel, validationReq, { errorsAsArray: false, forbidUndefinedVariables: false });
-            errors.should.not.exists;
+            var validRes = index.validation.process(validationModel, validationReq, { errorsAsArray: false, forbidUndefinedVariables: false });
+            validRes.should.be.empty;
 
-	    validationReq = { params: { foo: "foo", bar: "bar" } };
-	    
-            errors = index.validation.process(validationModel, validationReq, { errorsAsArray: true, forbidUndefinedVariables: true });
-            errors.should.be.an.instanceof(Array);
-            errors.length.should.equal(1);
-            errors[0].field.should.equal('bar');
-            errors[0].code.should.equal('UNDEFINED');
+            var invalidRes = index.validation.process(validationModel, validationReq, { errorsAsArray: true, forbidUndefinedVariables: true });
+            invalidRes.should.be.an.instanceof(Array);
+            invalidRes.length.should.equal(1);
+            invalidRes[0].reason.should.equal('Variable is not present');
+            invalidRes[0].type.should.equal('UNDEFINED');
 
             done();
         });
@@ -304,11 +301,11 @@ describe('Validation', function () {
             validationModelTrue.resources.status.isRequired = isRequiredTrue;
             validationModelTrue.resources.status.isIn = ['foo', 'bar'];
 
-            var errors1 = index.validation.process(validationModelTrue, validationReq, options);
-            errors1.should.be.an.instanceof(Array);
-            errors1.length.should.equal(1);
-            errors1[0].field.should.equal('status');
-            errors1[0].code.should.equal('MISSING');
+            var validationRes = index.validation.process(validationModelTrue, validationReq, options);
+            validationRes.should.be.an.instanceof(Array);
+            validationRes.length.should.equal(1);
+            validationRes[0].reason.should.equal('Field is required');
+            validationRes[0].type.should.equal('MISSING');
 
             done();
         });
@@ -337,20 +334,20 @@ describe('Validation', function () {
                 }
             };
 
-            var errors0 = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
-            errors0.length.should.equal(1);
-            errors0[0].field.should.equal('a');
-            errors0[0].code.should.equal('MISSING');
+            var checkMissing = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
+            checkMissing.length.should.equal(1);
+            checkMissing[0].reason.should.equal('Field is required');
+            checkMissing[0].type.should.equal('MISSING');
 
             validationReq.params.a = 'abc';
-            errors0 = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
-            errors0.length.should.equal(1);
-            errors0[0].field.should.equal('b');
-            errors0[0].code.should.equal('INVALID');
+            var checkInvalid = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
+            checkInvalid.length.should.equal(1);
+            checkInvalid[0].reason.should.equal('Needs to equal (THE OTHER FIELD)');
+            checkInvalid[0].type.should.equal('INVALID');
 
             validationReq.params.b = 'abc';
-            errors0 = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
-            errors0.length.should.equal(0);
+            var checkValid = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
+            checkValid.length.should.equal(0);
 
             done();
         });
@@ -372,7 +369,7 @@ it('node-validator error messages', function() {
 
   var errors = index.validation.process(validationModel, validationReq, options);
   errors.length.should.equal(3);
-  'Invalid IP'.should.equal(errors[0].message);
-  'Invalid ISBN'.should.equal(errors[1].message);
-  'Invalid value'.should.equal(errors[2].message);
+  'Invalid IP'.should.equal(errors[0].reason);
+  'Invalid ISBN'.should.equal(errors[1].reason);
+  'Invalid value'.should.equal(errors[2].reason);
 });


### PR DESCRIPTION
Since Restify 2.x, the query-string parameters have to be fetched using req.query() instead of req.query. While fixing the unit tests, i also upgraded the validator package to 3.22.x due to a major security issue in all versions below (see https://blog.liftsecurity.io/2014/11/03/regular-expression-dos-and-node.js).