### PR TITLE
Revert npm dependencies to most recent compatible versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   "main": "lib/index",
   "readmeFilename": "README.md",
   "dependencies": {
-    "lodash": "^4.16.6",
-    "validator": "6.1.x"
+    "lodash": "^3.10.x",
+    "validator": "3.22.x"
   },
   "devDependencies": {
     "restify": ">=2.8.1",


### PR DESCRIPTION
node-restify-validation is not compatible with lodash>=4.x.x and validator >=3.29.x