### PR TITLE
Fix bug with forbidUndefinedVariables

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -176,11 +176,23 @@ module.exports.process = function (validationModel, req, options) {
                     keys.splice(index, 1);
                 }
             });
-            if (options.forbidUndefinedVariables === true) {
-                keys.forEach(function(key) {
-                    addError(_createError(realScope, key, { name: "undefinedVariable" }));
-                });
-            }
+    	    if (options.forbidUndefinedVariables === true) {
+    	        keys.forEach(function(key) {
+                    var invalid = true;
+
+                    // check if key exist in some other scope in the validationModel
+                    _.each(validationModel, function (validationModelScope) {
+                        if (key in validationModelScope) {
+                            invalid = false;
+                        }
+                    });
+
+                    // flag key as undefined if it didn't show up in another scope
+                    if (invalid) {
+                        addError(_createError(realScope, key, { name: "undefinedVariable" }));
+                    }
+    	        });
+    	    }
         }
     });
     return errors;


### PR DESCRIPTION
The forbidUndefinedVariables check wrongly flagged keys that existed in other scopes as undefined, this fix checks for the key in the other scopes of the validationModel before flagging it as undefined.