### PR TITLE
Clarifying README.md and limiting Restify to 4.x.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Example:
         res.send(req.params);
     });
 
+    // Checks the body of the request contains a json payload with a 'label' attribute
     server.put({url: '/products/:id/labels/:label', validation: {
       resources: {
         id: { isRequired: true, isNatural: true },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "validator": "3.22.x"
   },
   "devDependencies": {
-    "restify": ">=2.8.1",
+    "restify": ">=2.8.1 <5.0.0",
     "mocha": "3.1.x",
     "sinon": "1.11.x",
     "should": "11.1.x",


### PR DESCRIPTION
Unittests fail with new version of Restify 5.0.0. Before adapting the library to this version I opted to force using a smaller version of Restify.
Added a small clarification on README.md as I did not find clear how to validate JSON bodies.