### PR TITLE
Add support for structured data (isObject and isArray)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,11 @@ Example:
         res.send(req.params);
     });
 
-    // Checks the body of the request contains a json payload with a 'label' attribute
+    // Checks the body of the request contains a json payload with a `person` object with the following attributes:
+    //   firstName - required
+    //   middle - optional
+    //   lastName - required
+    //   emails - optional array of email addresses with at most 5 elements
     server.put({url: '/products/:id/labels/:label', validation: {
       resources: {
         id: { isRequired: true, isNatural: true },
@@ -58,6 +62,21 @@ Example:
         status: { isRequired: true, isIn: ['foo','bar'] }
       },
       content: {
+        person: {
+            isObject: {
+                properties: {
+                    firstName: { isRequired: true },
+                    middle: { isRequired: false },
+                    lastName: { isRequired: true },
+                    emails: {
+                        isArray: {
+                            maxLength: 5,
+                            element: { isEmail: true }
+                        }
+                    }
+                }
+            }
+        },
         label: { isRequired: true }
       }
     }}, function (req, res, next) {
@@ -151,6 +170,79 @@ Powered by [node-validator](https://github.com/chriso/validator.js).
     notRegex
     regex
 
+## Nested validation
+
+Validation nesting allows validating content that contains objects and arrays.
+
+### isArray
+
+Validates that specified value is an array.  It can take a boolean value or
+an object with the following attributes:
+
+- minLength - minimum number of elements (use with `{ isRequired: true }`)
+- maxLength - maximum number of elements
+- element - validation specification for elements inside the array
+
+
+```
+{
+  content: {
+    comments: {
+        isArray: true
+    },
+    emailAddresses: {
+        isRequired: true,
+        isArray: {
+            minLength: 1,
+            maxLength: 10,
+            element: { isEmail: true }
+        }
+    }
+  }
+}
+```
+
+### isObject
+
+Validates that the specified value is an object.  It can take a boolean value or
+and object with the following attributes:
+
+- properties: validation specification for the contents of the object
+
+```
+{
+    content: {
+        data: {
+            isObject: true
+        },
+        person: {
+            isRequired: true,
+            isObject: {
+                properties: {
+                    first: { isRequired: true },
+                    last: { isRequired: true },
+                    middle: { isRequired: false },
+                    address: {
+                        isObject: {
+                            properties: {
+                                street: { isRequired: true },
+                                city: { isRequired: true },
+                                state: { isRequired: true }
+                            }
+                        }
+                    },
+                    emails: {
+                        isArray: {
+                            maxLength: 5,
+                            element: { isEmail: true }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+```
 
 ## Conditional validations
 All validation parameters are able to deal with functions as parameters.

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -52,8 +52,9 @@ module.exports._generateValidationChain = function (validationRules) {
     }, []);
 };
 
-module.exports.getValidatorChain = function (key, validationRules, validationModel, scope, req, options, recentErrors) {
-    var value = '['+scope+':'+key+']';
+module.exports.getValidatorChain = function (keys, validationRules, validationModel, scope, req, options, recentErrors) {
+    keys = keys || [];
+    var value = '['+scope+':'+keys.join('.')+']';
     if (req && req.route && req.route.name && _.has(validatorChainStore, req.route.name+value)) {
         return validatorChainStore[req.route.name+value];
     }
@@ -72,21 +73,29 @@ module.exports.getValidatorChain = function (key, validationRules, validationMod
     return validationChain;
 };
 
-module.exports.validateAttribute = function (key, validationRules, validationModel, scope, req, options, recentErrors) {
-    var validatorChain = this.getValidatorChain(key, validationRules, validationModel, scope, req, options, recentErrors);
+module.exports.validateAttribute = function (descriptor, keys, scopeValue, validationRules, validationModel, scope, req, options, recentErrors) {
+    var validatorChain = this.getValidatorChain(keys, validationRules, validationModel, scope, req, options, recentErrors);
     var self = this;
+    var key = _.last(keys);
 
-    var submittedValue = typeof req[scope] === 'function' ? req[scope]() : req[scope] !== undefined ? req[scope][key] : undefined;
+    var submittedValue = typeof scopeValue === 'function' ? scopeValue.apply(req) : scopeValue !== undefined ? scopeValue[key] : undefined;
     var supportsMultipleValues = validationRules.multiple === true;
     var isArray = _.isArray(submittedValue);
     var doSingleCheck = !(isArray && supportsMultipleValues);
+
     var context = {
         req: req,
         scope: scope,
         validationModel: validationModel,
         validationRules: validationRules,
         options: options,
-        recentErrors: recentErrors
+        recentErrors: recentErrors,
+        validateProperties: function(scopeValue, validationRules) {
+            return self.validateObject(descriptor, keys, scopeValue, validationRules, validationModel, scope, req, options, recentErrors, self);
+        },
+        validateValue: function(index, scopeValue, validationRules) {
+            return self.validateAttribute(descriptor + index, keys, scopeValue, validationRules, validationModel, scope, req, options, recentErrors);
+        }
     };
     // process the validatorChain and reduce it to the first error
     return _.reduce(validatorChain, function (memo, validator) {
@@ -121,17 +130,21 @@ module.exports.validateAttribute = function (key, validationRules, validationMod
         }
 
         if (result && !memo) {
-            return self.createError(scope, key, validator);
+            if (_.isObject(result)) {
+                return result;
+            } else {
+                return self.createError(scope, descriptor, validator);
+            }
         }
 
         return memo;
     }, '');
 };
 
-function _createError(scope, key, validator) {
+function _createError(scope, descriptor, validator) {
     var error = {
         scope: utils.getInternalScope(scope),
-        field: key,
+        field: descriptor,
         type: validatorCodes.codes[validator.name] || validatorCodes.codes._default
     };
 
@@ -140,6 +153,7 @@ function _createError(scope, key, validator) {
     if (message) {
         error.reason = message;
     }
+
 
     return error;
 }
@@ -152,48 +166,60 @@ module.exports.process = function (validationModel, req, options) {
     var errors = options.errorsAsArray === false ? {} : [];
     var self = this;
 
-    function addError(error, key) {
-        if (error) {
-            if (options.errorsAsArray === false) {
-                errors[key] = error;
-            } else {
-                errors.push(error);
-            }
-        }
-    };
-
     // fill missing fields with null
     _.each(validationModel, function (validationRulesScope, scope) {
         var realScope = utils.getExternalScope(scope);
         if(!realScope) {
-            addError(_createError(scope, realScope, {msg: "Invalid scope. Must be in [" + utils.getScopeKeys + "]."}), realScope);
+            addError(errors, _createError(scope, realScope, {msg: "Invalid scope. Must be in [" + utils.getScopeKeys + "]."}), realScope, options);
         } else {
-            var keys = req[realScope] ? ( typeof req[realScope] === 'object' ? Object.keys(req[realScope]) : [] ) : [];
-            _.each(validationRulesScope, function (validationRules, key) {
-                addError(self.validateAttribute(key, validationRules, validationModel, realScope, req, options, errors), key);
-                var index = keys.indexOf(key);
-                if (index > -1) {
-                    keys.splice(index, 1);
-                }
-            });
-    	    if (options.forbidUndefinedVariables === true) {
-    	        keys.forEach(function(key) {
-                    var invalid = true;
-
-                    // check if key exist in some other scope in the validationModel
-                    _.each(validationModel, function (validationModelScope) {
-                        if (key in validationModelScope) {
-                            invalid = false;
-                        }
-                    });
-
-                    // flag key as undefined if it didn't show up in another scope
-                    if (invalid) {
-                        addError(_createError(realScope, key, { name: "undefinedVariable" }));
-                    }
-    	        });
-    	    }
+            self.validateObject("", [], req[realScope], validationRulesScope, validationModel, realScope, req, options, errors);
         }
     });
     return errors;
+};
+
+function addError(errors, error, key, options) {
+    if (error) {
+        if (options.errorsAsArray === false) {
+            errors[key] = error;
+        } else {
+            errors.push(error);
+        }
+    }
+}
+
+function describeKey(descriptor, key) {
+    return descriptor ? descriptor + '.' + key : key;
+}
+
+module.exports.validateObject = function (descriptor, keys, scopeValue, validationRulesScope, validationModel, realScope, req, options, errors) {
+    var self = this;
+    try {
+        var keys = scopeValue ? (typeof scopeValue === 'object' ? Object.keys(scopeValue) : []) : [];
+        _.each(validationRulesScope, function (validationRules, key) {
+            addError(errors, self.validateAttribute(describeKey(descriptor, key), keys.concat([key]), scopeValue, validationRules, validationModel, realScope, req, options, errors), key, options);
+            var index = keys.indexOf(key);
+            if (index > -1) {
+                keys.splice(index, 1);
+            }
+        });
+        if (options.forbidUndefinedVariables === true) {
+            keys.forEach(function (key) {
+                var invalid = true;
+
+                // check if key exist in some other scope in the validationModel
+                _.each(validationModel, function (validationModelScope) {
+                    if (key in validationModelScope) {
+                        invalid = false;
+                    }
+                });
+
+                // flag key as undefined if it didn't show up in another scope
+                if (invalid) {
+                    addError(errors, _createError(realScope, describeKey(descriptor, key), {name: "undefinedVariable"}), undefined, options);
+                }
+            });
+        }
+    } catch (e) {
+    }
 };

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -40,6 +40,28 @@ var validators = module.exports = {
         if (!_.isEqual(submittedValue, this.req[this.scope][myValidator.value])) {
             return true;
         }
+    },
+    isArray: function (key, submittedValue, myValidator) {
+        var isArray = _.isFunction(myValidator.value) ? myValidator.value.call(this, key, myValidator) : myValidator.value;
+
+        if (!isArray) {
+            if (_.isArray(submittedValue)) {
+                myValidator.msg = 'Field is an array';
+                return true;
+            }
+        } else if (!_.isArray(submittedValue)) {
+            myValidator.msg = 'Field is not array';
+            return true;
+        } else if (_.isObject(isArray)) {
+            if (isArray.minLength && submittedValue.length < isArray.minLength) {
+                myValidator.msg = 'Not enough elements';
+                return true;
+            }
+            if (isArray.maxLength && submittedValue.length > isArray.maxLength) {
+                myValidator.msg = 'Too many elements';
+                return true;
+            }
+        }
     }
 };
 

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -49,10 +49,10 @@ var validators = module.exports = {
                 myValidator.msg = 'Field is an array';
                 return true;
             }
-        } else if (!_.isArray(submittedValue)) {
+        } else if (submittedValue && !_.isArray(submittedValue)) {
             myValidator.msg = 'Field is not array';
             return true;
-        } else if (_.isObject(isArray)) {
+        } else if (submittedValue && _.isObject(isArray)) {
             if (isArray.minLength && submittedValue.length < isArray.minLength) {
                 myValidator.msg = 'Not enough elements';
                 return true;

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -61,6 +61,11 @@ var validators = module.exports = {
                 myValidator.msg = 'Too many elements';
                 return true;
             }
+            if (isArray.element && submittedValue) {
+                return _.reduce(submittedValue, function(previousError, value, index) {
+                    return previousError || this.validateValue('[' + index + ']', _.constant(value), isArray.element);
+                }, false, this);
+            }
         }
     },
     isObject: function (key, submittedValue, myValidator) {
@@ -73,6 +78,10 @@ var validators = module.exports = {
         } else if (!_.isObject(submittedValue) || _.isArray(submittedValue)) {
             myValidator.msg = 'Field is not object';
             return true;
+        } else if (_.isObject(isObject)) {
+            if (isObject.properties) {
+                return this.validateProperties(submittedValue, isObject.properties);
+            }
         }
     }
 };

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -62,6 +62,18 @@ var validators = module.exports = {
                 return true;
             }
         }
+    },
+    isObject: function (key, submittedValue, myValidator) {
+        var isObject = _.isFunction(myValidator.value) ? myValidator.value.call(this, key, myValidator) : myValidator.value;
+        if (!isObject) {
+            if (_.isObject(submittedValue) && !_.isArray(submittedValue)) {
+                myValidator.msg = 'Field is an object';
+                return true;
+            }
+        } else if (!_.isObject(submittedValue) || _.isArray(submittedValue)) {
+            myValidator.msg = 'Field is not object';
+            return true;
+        }
     }
 };
 

--- a/test/integrations/validator_test.js
+++ b/test/integrations/validator_test.js
@@ -177,4 +177,11 @@ describe('Validators', function () {
     it('node-validator arrays', function() {
         test('isInt', true, '123', [['456', '0.123']]);
     });
+
+    it('isArray', function() {
+        test('isArray', false, [123, 'string'], [[123], ['string', 123, false]]);
+        test('isArray', true, [[123], ['string', 123, false]], [123, 'string']);
+        test('isArray', { minLength: 2 }, [[1,2], [1, 2, 3]], [123, [1]]);
+        test('isArray', { maxLength: 3 }, [[1], [1, 2, 3]], [123, [1,2,3,4]]);
+    });
 });

--- a/test/integrations/validator_test.js
+++ b/test/integrations/validator_test.js
@@ -183,10 +183,84 @@ describe('Validators', function () {
         test('isArray', true, [[123], ['string', 123, false]], [123, 'string']);
         test('isArray', { minLength: 2 }, [[1,2], [1, 2, 3]], [123, [1]]);
         test('isArray', { maxLength: 3 }, [[1], [1, 2, 3]], [123, [1,2,3,4]]);
+        test('isArray', { element: { isNatural: true } }, [[1], [1, 2, 3]], [["a"], [-1]]);
+        var validationModel = {
+            element: {
+                isObject: {
+                    properties: {
+                        name: { isRequired: true },
+                        age: { isNatural: true, isRequired: false }
+                    }
+                }
+            }
+        };
+        test('isArray', validationModel, [[{
+            name: "Alice"
+        }, {
+            name: "Bob",
+            age: 33
+        }]], [["a"], [{
+            name: "Alice",
+            age: -5
+        }]]);
     });
 
     it('isObject', function() {
         test('isObject', false, [123, 'string', [123]], [{}, {name:"bob"}]);
         test('isObject', true, [{}, {name:"bob"}], [123, 'string', [123]]);
+        test('isObject', { properties: { value: { isNatural: true } }}, [{value:123}, {value:123, name:'bob'}], [{value:-5}, {value:'abc'}]);
+        var validationModel = {
+            properties: {
+                address: {
+                    isObject: {
+                        properties: {
+                            street: {
+                                isRequired: true
+                            },
+                            city: {
+                                isRequired: true
+                            },
+                            zip: {
+                                isNatural: true
+                            }
+                        }
+                    }
+                },
+                luckyNumbers: {
+                    isArray: {
+                        element: {
+                            isNatural: true
+                        }
+                    }
+                }
+            }
+        };
+        test('isObject', validationModel, [{
+            address: {
+                street: 'Elm Street',
+                city: 'Springfield',
+                zip: 12345
+            }
+        }, {
+            address: {
+                street: 'Elm Street',
+                city: 'Springfield',
+                zip: 12345
+            },
+            luckyNumbers: [1, 13, 888]
+        }], ['test', 123, {
+            address: {
+                street: 'Elm Street',
+                city: 'Springfield',
+                zip: -5
+            }
+        }, {
+            address: {
+                street: 'Elm Street',
+                city: 'Springfield',
+                zip: 12345
+            },
+            luckyNumbers: [1, "not a number", 888]
+        }]);
     });
 });

--- a/test/integrations/validator_test.js
+++ b/test/integrations/validator_test.js
@@ -184,4 +184,9 @@ describe('Validators', function () {
         test('isArray', { minLength: 2 }, [[1,2], [1, 2, 3]], [123, [1]]);
         test('isArray', { maxLength: 3 }, [[1], [1, 2, 3]], [123, [1,2,3,4]]);
     });
+
+    it('isObject', function() {
+        test('isObject', false, [123, 'string', [123]], [{}, {name:"bob"}]);
+        test('isObject', true, [{}, {name:"bob"}], [123, 'string', [123]]);
+    });
 });

--- a/test/units/validation_test.js
+++ b/test/units/validation_test.js
@@ -353,52 +353,57 @@ describe('Validation', function () {
         });
 
         describe('isArray', function() {
-            var validationReq = { body: {
+            var validationReq = {
+                body: {
                     numArr: [1, 2, 34],
                     numArrNull: [1, 2, null, 34],
                     strVal: "I'm just a string"
                 }
             };
 
-            it ('should accept array when true', function() {
-                var validationModel = { content: {
-                        numArrNull: { isArray: true }
+            it('accept array when true', function () {
+                var validationModel = {
+                    content: {
+                        numArrNull: {isArray: true}
                     }
                 };
-                var checkInvalid = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
+                var checkInvalid = index.validation.process(validationModel, validationReq, {errorsAsArray: true});
                 checkInvalid.length.should.equal(0);
             });
 
-            it ('should reject non-array when true', function() {
-                var validationModel = { content: {
-                        strVal: { isArray: true }
+            it('reject non-array when true', function () {
+                var validationModel = {
+                    content: {
+                        strVal: {isArray: true}
                     }
                 };
-                var checkInvalid = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
+                var checkInvalid = index.validation.process(validationModel, validationReq, {errorsAsArray: true});
                 checkInvalid.length.should.equal(1);
                 checkInvalid[0].reason.should.equal('Field is not array');
                 checkInvalid[0].type.should.equal('INVALID');
             });
 
-            it ('should reject array when false', function() {
-                var validationModel = { content: {
-                        numArr: { isArray: false }
+            it('reject array when false', function () {
+                var validationModel = {
+                    content: {
+                        numArr: {isArray: false}
                     }
                 };
-                var checkInvalid = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
+                var checkInvalid = index.validation.process(validationModel, validationReq, {errorsAsArray: true});
                 checkInvalid.length.should.equal(1);
                 checkInvalid[0].reason.should.equal('Field is an array');
                 checkInvalid[0].type.should.equal('INVALID');
             });
 
-            it ('should validate minLength', function() {
-                var validationModel = { content: {
-                        numArr: { isArray: {} }
+            it('validate minLength', function () {
+                var validationModel = {
+                    content: {
+                        numArr: {isArray: {}}
                     }
                 };
 
                 validationModel.content.numArr.isArray.minLength = 1;
-                var checkInvalidOk = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
+                var checkInvalidOk = index.validation.process(validationModel, validationReq, {errorsAsArray: true});
                 checkInvalidOk.length.should.equal(0);
 
                 validationModel.content.numArr.isArray.minLength = 5;
@@ -408,9 +413,10 @@ describe('Validation', function () {
                 checkInvalidFail[0].type.should.equal('INVALID');
             });
 
-            it ('should validate maxLength', function() {
-                var validationModel = { content: {
-                        numArr: { isArray: {} }
+            it('validate maxLength', function () {
+                var validationModel = {
+                    content: {
+                        numArr: {isArray: {}}
                     }
                 };
 
@@ -424,43 +430,55 @@ describe('Validation', function () {
                 checkInvalidFail[0].reason.should.equal('Too many elements');
                 checkInvalidFail[0].type.should.equal('INVALID');
             });
+
         });
 
-        describe('isObject', function() {
-            var validationReq = { body: {
-                    objVal: { name: "Bob" },
+        describe('isObject', function () {
+            var validationReq = {
+                body: {
+                    person: {
+                        name: "Bob",
+                        age: 50,
+                        preferences: {
+                            favoriteNumber: -333
+                        }
+                    },
                     strVal: "I'm just a string",
                     arrVal: [123, "bob"]
                 }
             };
 
-            it ('accept object when true', function() {
-                var validationModel = { content: {
-                        objVal: { isObject: true }
+            it('accept object when true', function () {
+                var validationModel = {
+                    content: {
+                        person: {isObject: true}
                     }
                 };
-                var checkInvalid = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
+                var checkInvalid = index.validation.process(validationModel, validationReq, {errorsAsArray: true});
                 checkInvalid.length.should.equal(0);
             });
 
-            it ('reject non-object when true', function() {
-                var checkInvalidString = index.validation.process({ content: { strVal: { isObject: true } } }, validationReq, { errorsAsArray: true });
+            it('reject non-object when true', function () {
+                var checkInvalidString = index.validation.process({content: {strVal: {isObject: true}}}, validationReq, {errorsAsArray: true});
                 checkInvalidString.length.should.equal(1);
                 checkInvalidString[0].reason.should.equal('Field is not object');
                 checkInvalidString[0].type.should.equal('INVALID');
+                checkInvalidString[0].field.should.equal('strVal');
 
-                var checkInvalidArray = index.validation.process({ content: { arrVal: { isObject: true } } }, validationReq, { errorsAsArray: true });
+                var checkInvalidArray = index.validation.process({content: {arrVal: {isObject: true}}}, validationReq, {errorsAsArray: true});
                 checkInvalidArray.length.should.equal(1);
                 checkInvalidArray[0].reason.should.equal('Field is not object');
                 checkInvalidArray[0].type.should.equal('INVALID');
+                checkInvalidArray[0].field.should.equal('arrVal');
             });
 
-            it ('reject object when false', function() {
-                var validationModel = { content: {
-                        objVal: { isObject: false }
+            it('reject object when false', function () {
+                var validationModel = {
+                    content: {
+                        person: {isObject: false}
                     }
                 };
-                var checkInvalid = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
+                var checkInvalid = index.validation.process(validationModel, validationReq, {errorsAsArray: true});
                 checkInvalid.length.should.equal(1);
                 checkInvalid[0].reason.should.equal('Field is an object');
                 checkInvalid[0].type.should.equal('INVALID');

--- a/test/units/validation_test.js
+++ b/test/units/validation_test.js
@@ -353,13 +353,17 @@ describe('Validation', function () {
         });
 
         describe('isArray', function() {
-            var validationReq = {
-                body: {
-                    numArr: [1, 2, 34],
-                    numArrNull: [1, 2, null, 34],
-                    strVal: "I'm just a string"
-                }
-            };
+            var validationReq;
+
+            beforeEach(function() {
+                validationReq = {
+                    body: {
+                        numArr: [1, 2, 34],
+                        numArrNull: [1, 2, null, 34],
+                        strVal: "I'm just a string"
+                    }
+                };
+            });
 
             it('accept array when true', function () {
                 var validationModel = {
@@ -403,14 +407,18 @@ describe('Validation', function () {
                 };
 
                 validationModel.content.numArr.isArray.minLength = 1;
-                var checkInvalidOk = index.validation.process(validationModel, validationReq, {errorsAsArray: true});
-                checkInvalidOk.length.should.equal(0);
+                var checkInvalidLength = index.validation.process(validationModel, validationReq, {errorsAsArray: true});
+                checkInvalidLength.length.should.equal(0);
 
                 validationModel.content.numArr.isArray.minLength = 5;
-                var checkInvalidFail = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
-                checkInvalidFail.length.should.equal(1);
-                checkInvalidFail[0].reason.should.equal('Not enough elements');
-                checkInvalidFail[0].type.should.equal('INVALID');
+                var checkTooShorts = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
+                checkTooShorts.length.should.equal(1);
+                checkTooShorts[0].reason.should.equal('Not enough elements');
+                checkTooShorts[0].type.should.equal('INVALID');
+
+                delete validationReq.body.numArr;
+                var checkMissing = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
+                checkMissing.length.should.equal(0);
             });
 
             it('validate maxLength', function () {
@@ -421,14 +429,18 @@ describe('Validation', function () {
                 };
 
                 validationModel.content.numArr.isArray.maxLength = 10;
-                var checkInvalidOk = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
-                checkInvalidOk.length.should.equal(0);
+                var checkInvalidValidLength = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
+                checkInvalidValidLength.length.should.equal(0);
 
                 validationModel.content.numArr.isArray.maxLength = 2;
-                var checkInvalidFail = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
-                checkInvalidFail.length.should.equal(1);
-                checkInvalidFail[0].reason.should.equal('Too many elements');
-                checkInvalidFail[0].type.should.equal('INVALID');
+                var checkTooLong = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
+                checkTooLong.length.should.equal(1);
+                checkTooLong[0].reason.should.equal('Too many elements');
+                checkTooLong[0].type.should.equal('INVALID');
+
+                delete validationReq.body.numArr;
+                var checkMissing = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
+                checkMissing.length.should.equal(0);
             });
 
         });

--- a/test/units/validation_test.js
+++ b/test/units/validation_test.js
@@ -351,6 +351,80 @@ describe('Validation', function () {
 
             done();
         });
+
+        describe('isArray', function() {
+            var validationReq = { body: {
+                    numArr: [1, 2, 34],
+                    numArrNull: [1, 2, null, 34],
+                    strVal: "I'm just a string"
+                }
+            };
+
+            it ('should accept array when true', function() {
+                var validationModel = { content: {
+                        numArrNull: { isArray: true }
+                    }
+                };
+                var checkInvalid = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
+                checkInvalid.length.should.equal(0);
+            });
+
+            it ('should reject non-array when true', function() {
+                var validationModel = { content: {
+                        strVal: { isArray: true }
+                    }
+                };
+                var checkInvalid = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
+                checkInvalid.length.should.equal(1);
+                checkInvalid[0].reason.should.equal('Field is not array');
+                checkInvalid[0].type.should.equal('INVALID');
+            });
+
+            it ('should reject array when false', function() {
+                var validationModel = { content: {
+                        numArr: { isArray: false }
+                    }
+                };
+                var checkInvalid = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
+                checkInvalid.length.should.equal(1);
+                checkInvalid[0].reason.should.equal('Field is an array');
+                checkInvalid[0].type.should.equal('INVALID');
+            });
+
+            it ('should validate minLength', function() {
+                var validationModel = { content: {
+                        numArr: { isArray: {} }
+                    }
+                };
+
+                validationModel.content.numArr.isArray.minLength = 1;
+                var checkInvalidOk = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
+                checkInvalidOk.length.should.equal(0);
+
+                validationModel.content.numArr.isArray.minLength = 5;
+                var checkInvalidFail = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
+                checkInvalidFail.length.should.equal(1);
+                checkInvalidFail[0].reason.should.equal('Not enough elements');
+                checkInvalidFail[0].type.should.equal('INVALID');
+            });
+
+            it ('should validate maxLength', function() {
+                var validationModel = { content: {
+                        numArr: { isArray: {} }
+                    }
+                };
+
+                validationModel.content.numArr.isArray.maxLength = 10;
+                var checkInvalidOk = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
+                checkInvalidOk.length.should.equal(0);
+
+                validationModel.content.numArr.isArray.maxLength = 2;
+                var checkInvalidFail = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
+                checkInvalidFail.length.should.equal(1);
+                checkInvalidFail[0].reason.should.equal('Too many elements');
+                checkInvalidFail[0].type.should.equal('INVALID');
+            });
+        });
     });
 });
 

--- a/test/units/validation_test.js
+++ b/test/units/validation_test.js
@@ -425,6 +425,47 @@ describe('Validation', function () {
                 checkInvalidFail[0].type.should.equal('INVALID');
             });
         });
+
+        describe('isObject', function() {
+            var validationReq = { body: {
+                    objVal: { name: "Bob" },
+                    strVal: "I'm just a string",
+                    arrVal: [123, "bob"]
+                }
+            };
+
+            it ('accept object when true', function() {
+                var validationModel = { content: {
+                        objVal: { isObject: true }
+                    }
+                };
+                var checkInvalid = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
+                checkInvalid.length.should.equal(0);
+            });
+
+            it ('reject non-object when true', function() {
+                var checkInvalidString = index.validation.process({ content: { strVal: { isObject: true } } }, validationReq, { errorsAsArray: true });
+                checkInvalidString.length.should.equal(1);
+                checkInvalidString[0].reason.should.equal('Field is not object');
+                checkInvalidString[0].type.should.equal('INVALID');
+
+                var checkInvalidArray = index.validation.process({ content: { arrVal: { isObject: true } } }, validationReq, { errorsAsArray: true });
+                checkInvalidArray.length.should.equal(1);
+                checkInvalidArray[0].reason.should.equal('Field is not object');
+                checkInvalidArray[0].type.should.equal('INVALID');
+            });
+
+            it ('reject object when false', function() {
+                var validationModel = { content: {
+                        objVal: { isObject: false }
+                    }
+                };
+                var checkInvalid = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
+                checkInvalid.length.should.equal(1);
+                checkInvalid[0].reason.should.equal('Field is an object');
+                checkInvalid[0].type.should.equal('INVALID');
+            });
+        });
     });
 });
 


### PR DESCRIPTION
Restify-Validation is great for validating route params, headers, queries and form-submissions, and  simple name/value JSON requests.

This PR adds validation support for JSON requests with structured data (i.e. arrays, objects, arrays of objects, etc.) by adding **isArray** (minLength, maxLength, element) and **isObject** (properties) validation configurations:

```javascript
server.put({url: '/products/:id/labels/:label', validation: {
  content: {
    person: {
        isObject: {
            properties: {
                firstName: { isRequired: true },
                middle: { isRequired: false },
                lastName: { isRequired: true },
                emails: {
                    isArray: {
                        maxLength: 5,
                        element: { isEmail: true }
                    }
                }
            }
        }
    },
    label: { isRequired: true }
  }
}}, function (req, res, next) {
    res.send(req.params);
});
```
The README.md contains more details and examples.