### PR TITLE
Support for specifying property model

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,9 +284,10 @@ The request `resource`, `query` and `headers` contain string values, even though
 be representing numbers, booleans, Dates or other types.
 
 An optional `model` property can be specified to transform the request value to a specific type.
-When validation of a property succeeds and a `model` is specified, the original request value is replaced with the transformed value.
+When validation of a property succeeds and a `model` is specified, the original request value
+is replaced with the transformed value.
 
-```javasecript
+```javascript
 // Creates an instance of date from a numeric or string value
 function DateModel(value) {
     return new Date(Number(value) || value);

--- a/README.md
+++ b/README.md
@@ -278,6 +278,48 @@ As result the parameter will only be required when param1 matches a or b. The ca
 * options: the options which have initially been passed
 * recentErrors: errors which have been computed until now
 
+## Model
+
+The request `resource`, `query` and `headers` contain string values, even though they may
+be representing numbers, booleans, Dates or other types.
+
+An optional `model` property can be specified to transform the request value to a specific type.
+When validation of a property succeeds and a `model` is specified, the original request value is replaced with the transformed value.
+
+```javasecript
+// Creates an instance of date from a numeric or string value
+function DateModel(value) {
+    return new Date(Number(value) || value);
+}
+
+server.get({url: '/search', validation: {
+    queries: {
+        text: { isRequired: true },
+        from: { model: DateModel },
+        to: { model: DateModel },
+        summary: { isBoolean, model: Boolean },
+        page: { isNumber: true, model: Number }
+    }
+}, function (req, res, next) {
+    console.log("Query:", JSON.stringify(req.query));
+    res.send(req.query);
+}))
+```
+
+When handling the request `GET /search?text=Hello&from=2017-12-1&to=1514678400000&summary=true&page=3`,
+the query property types will be `string`, `number`, `Date`, `Date` and `number`, respectively
+and the following will be logged:
+
+```
+Query: {"text":"Hello","from":"2017-12-01T06:00:00.000Z","to":"2017-12-31T00:00:00.000Z","summary":true,"page":3}
+```
+
+Without specifying the `model` settings, the query property types would have been strings and the following would
+have been logged:
+
+```
+Query: {"text":"Hello","from":"2017-12-1","to":"1514678400000","summary":"true","page":"3"}
+```
 
 ## Inspiration
 node-restify-validation was & is inspired by [backbone.validation](https://github.com/thedersen/backbone.validation).

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -98,7 +98,7 @@ module.exports.validateAttribute = function (descriptor, keys, scopeValue, valid
         }
     };
     // process the validatorChain and reduce it to the first error
-    return _.reduce(validatorChain, function (memo, validator) {
+    var error = _.reduce(validatorChain, function (memo, validator) {
         var result;
 
         if (doSingleCheck) {
@@ -139,6 +139,16 @@ module.exports.validateAttribute = function (descriptor, keys, scopeValue, valid
 
         return memo;
     }, '');
+    if (error) {
+        return {
+            error: error,
+            value: submittedValue
+        };
+    } else {
+        return {
+            value: submittedValue
+        };
+    }
 };
 
 function _createError(scope, descriptor, validator) {
@@ -197,7 +207,13 @@ module.exports.validateObject = function (descriptor, keys, scopeValue, validati
     try {
         var keys = scopeValue ? (typeof scopeValue === 'object' ? Object.keys(scopeValue) : []) : [];
         _.each(validationRulesScope, function (validationRules, key) {
-            addError(errors, self.validateAttribute(describeKey(descriptor, key), keys.concat([key]), scopeValue, validationRules, validationModel, realScope, req, options, errors), key, options);
+
+            var attribute = self.validateAttribute(describeKey(descriptor, key), keys.concat([key]), scopeValue, validationRules, validationModel, realScope, req, options, errors);
+            if (attribute.error) {
+                addError(errors, attribute.error, key, options);
+            } else {
+                scopeValue[key] = attribute.value;
+            }
             var index = keys.indexOf(key);
             if (index > -1) {
                 keys.splice(index, 1);

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -146,7 +146,7 @@ module.exports.validateAttribute = function (descriptor, keys, scopeValue, valid
         };
     } else {
         return {
-            value: submittedValue
+            value: validationRules.model ? validationRules.model(submittedValue) : submittedValue
         };
     }
 };

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License
  *
  * Copyright 2014 Timo Behrmann, Guillaume Chauvet.
@@ -26,7 +26,7 @@ var validator = require('./compatible-validator');
 var utils = require('./utils');
 
 var validators = module.exports = {
-    
+
     isRequired: function (key, submittedValue, myValidator) {
         var isRequired = _.isFunction(myValidator.value) ? myValidator.value.call(this, key, myValidator) : myValidator.value;
 
@@ -63,7 +63,14 @@ var validators = module.exports = {
             }
             if (isArray.element && submittedValue) {
                 return _.reduce(submittedValue, function(previousError, value, index) {
-                    return previousError || this.validateValue('[' + index + ']', _.constant(value), isArray.element);
+                    if (previousError) {
+                        return previousError;
+                    }
+                    var validateValue = this.validateValue('[' + index + ']', _.constant(value), isArray.element);
+                    if (!validateValue.error) {
+                        submittedValue[index] = validateValue.value;
+                    }
+                    return validateValue.error;
                 }, false, this);
             }
         }

--- a/test/units/model_test.js
+++ b/test/units/model_test.js
@@ -1,0 +1,109 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 Stepan Riha.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+var index = require('../../lib/index');
+
+describe('Model', function() {
+
+    var validationReq;
+    var timeStamp = new Date();
+
+    beforeEach(function() {
+        validationReq = {
+            params: { num: '-123.5' },
+            query: {
+                flag: 'true',
+                scores: ['1', '2', '100']
+            },
+            body: {
+                from: timeStamp.toISOString(),
+                to: timeStamp.valueOf(),
+                ts: String(timeStamp.valueOf())
+            }
+        };
+    });
+
+    describe("not specified", function() {
+        it ('should keep original value', function() {
+            var validationModel = {
+                resources: {
+                    num: { isDecimal: true }
+                }
+            };
+
+            var validationResult = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
+            validationResult.length.should.equal(0);
+            validationReq.params.num.should.equal('-123.5');
+        });
+    });
+
+    describe("when validation fails", function() {
+        it ('should keep original value', function() {
+            var validationModel = {
+                resources: {
+                    num: { isNatural: true, model: Number }
+                }
+            };
+
+            var validationResult = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
+            validationResult.length.should.equal(1);
+            validationReq.params.num.should.equal('-123.5');
+        });
+    });
+
+    describe("when validation passes", function() {
+        it ('should use model value', function() {
+            function DateModel(value) {
+                return new Date(Number(value) || value);
+            }
+            var validationModel = {
+                resources: {
+                    num: { model: Number }
+                },
+                queries: {
+                    flag: { model: Boolean },
+                    scores: {
+                        isArray: {
+                            element: { model: Number }
+                        }
+                    }
+                },
+                content: {
+                    from: { model: DateModel },
+                    to: { model: DateModel },
+                    ts: { model: DateModel }
+                }
+            };
+
+            var validationResult = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
+            validationResult.length.should.equal(0);
+            validationReq.params.num.should.equal(-123.5);
+            validationReq.query.flag.should.equal(true);
+            validationReq.query.scores.should.deepEqual([1, 2, 100]);
+            validationReq.body.from.should.deepEqual(timeStamp);
+            validationReq.body.to.should.deepEqual(timeStamp);
+            validationReq.body.ts.should.deepEqual(timeStamp);
+        });
+    });
+
+});


### PR DESCRIPTION
Except for (JSON) request content, request parameters (query, params, headers) contain **string** values.  So even though in your validation you ensure that they match a number or boolean, the application code still needs to deal with type conversions.

In this PR an optional `model` property can be specified to transform the request value to a specific type. When validation of a property succeeds and a `model` is specified, the original request value is replaced with the transformed value.

```javascript
// Creates an instance of date from a numeric or string value
function DateModel(value) {
    return new Date(Number(value) || value);
}

server.get({url: '/search', validation: {
    queries: {
        text: { isRequired: true },
        from: { model: DateModel },
        to: { model: DateModel },
        summary: { isBoolean, model: Boolean },
        page: { isNumber: true, model: Number }
    }
}, function (req, res, next) {
    console.log("Query:", JSON.stringify(req.query));
    res.send(req.query);
}))
```

When handling the request `GET /search?text=Hello&from=2017-12-1&to=1514678400000&summary=true&page=3`, the query property types will be `string`, `number`, `Date`, `Date` and `number`, respectively and the following will be logged:

```
Query: {"text":"Hello","from":"2017-12-01T06:00:00.000Z","to":"2017-12-31T00:00:00.000Z","summary":true,"page":3}
```

Without specifying the `model` settings, the query property types would have been strings and the following would have been logged:

```
Query: {"text":"Hello","from":"2017-12-1","to":"1514678400000","summary":"true","page":"3"}
```

