### PR TITLE
Configurable Validator Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ As result the parameter will only be required when param1 matches a or b. The ca
 * options: the options which have initially been passed
 * recentErrors: errors which have been computed until now
 
-## Model
+## Models
 
 The request `resource`, `query` and `headers` contain string values, even though they may
 be representing numbers, booleans, Dates or other types.
@@ -299,7 +299,7 @@ server.get({url: '/search', validation: {
         from: { model: DateModel },
         to: { model: DateModel },
         summary: { isBoolean, model: Boolean },
-        page: { isNumber: true, model: Number }
+        page: { isNatural: true, model: Number }
     }
 }, function (req, res, next) {
     console.log("Query:", JSON.stringify(req.query));
@@ -322,10 +322,47 @@ have been logged:
 Query: {"text":"Hello","from":"2017-12-1","to":"1514678400000","summary":"true","page":"3"}
 ```
 
+### Validator Models
+
+To avoid having to specify models in your validation configurations, you can
+configure models to be automatically applied based on the validator.
+
+```javascript
+server.use(restifyValidation.validationPlugin({
+    validatorModels: {
+        isInt: Number
+    }
+}));
+```
+
+When you specify the standard `restifyValidation.validatorModels`, it will supply models
+for the following validators:
+
+- isBoolean - converts value to `boolean`
+- isDate - converts value to `Date`
+- isDecimal - converts value to `number`
+- isDivisibleBy - converts value to `number`
+- isFloat - converts value to `number`
+- isInt - converts value to `number`
+- isNatural - converts value to `number`
+
+The `validatorModels` configuration can also take an array of settings.
+The following example uses `restifyValidation.validatorModels` but then overrides
+the model for the `isDate` validator to map values to `moment` rather than to `Date`.
+
+```javascript
+var moment = require('moment');
+server.use(restifyValidation.validationPlugin({
+    validatorModels: [
+        restifyValidation.validatorModels,
+        { isDate: moment }
+    ]
+}));
+```
+
 ## Inspiration
 node-restify-validation was & is inspired by [backbone.validation](https://github.com/thedersen/backbone.validation).
 In terms of validation node-restify-validation makes use of [node-validator](https://github.com/chriso/node-validator).
-
 
 ## License
 The MIT License (MIT)

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,21 +25,30 @@ var _ = require('lodash');
 var self = {
   validation: require('./validation'),
   error: require('./error'),
+  model: require('./model'),
   when: require('./conditions')
 };
 
 module.exports.validation = self.validation;
 module.exports.error = self.error;
 module.exports.when = self.when;
+module.exports.validatorModels = self.model.validatorModels;
 
 var defaultOptions = {
     errorsAsArray: true,
     errorHandler: false,
-    forbidUndefinedVariables: false
+    forbidUndefinedVariables: false,
+    validatorModels: {}
 };
 
 module.exports.validationPlugin = function (options) {
-    options = _.extend(defaultOptions, options);
+    options = _.extend({}, defaultOptions, options);
+    if (_.isArray(options.validatorModels)) {
+        // Combine list of validatorModels
+        var validatorModels = _.toArray(options.validatorModels);
+        validatorModels.unshift({});
+        options.validatorModels = _.extend.apply(null, validatorModels);
+    }
     return function (req, res, next) {
         var validationModel = req.route ? req.route.validation : undefined;
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -1,0 +1,47 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 Stepan Riha.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+function booleanModel(val) {
+    return val === 'true' || val === true;
+}
+
+function dateModel(val) {
+    return new Date(Number(val) || val);
+}
+
+var numberModel = Number;
+
+module.exports.booleanModel = booleanModel;
+module.exports.dateModel = dateModel;
+module.exports.numberModel = numberModel;
+
+module.exports.validatorModels = {
+    isBoolean: booleanModel,
+    isDate: dateModel,
+    isDecimal: numberModel,
+    isDivisibleBy: numberModel,
+    isFloat: numberModel,
+    isInt: numberModel,
+    isNatural: numberModel
+};

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -98,9 +98,13 @@ module.exports.validateAttribute = function (descriptor, keys, scopeValue, valid
         }
     };
     // process the validatorChain and reduce it to the first error
+    var validatorModels = options.validatorModels || {};
+    var model = validationRules.model;
     var error = _.reduce(validatorChain, function (memo, validator) {
         var result;
-
+        if (!model) {
+            model = validatorModels[validator.name];
+        }
         if (doSingleCheck) {
             try {
                 result = validator.fn.call(context, key, submittedValue, validator);
@@ -146,7 +150,7 @@ module.exports.validateAttribute = function (descriptor, keys, scopeValue, valid
         };
     } else {
         return {
-            value: validationRules.model ? validationRules.model(submittedValue) : submittedValue
+            value: model ? model(submittedValue) : submittedValue
         };
     }
 };

--- a/test/units/model_test.js
+++ b/test/units/model_test.js
@@ -21,19 +21,22 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+var _ = require('lodash');
 var index = require('../../lib/index');
 
-describe('Model', function() {
+describe('Model', function () {
 
     var validationReq;
     var timeStamp = new Date();
 
-    beforeEach(function() {
+    beforeEach(function () {
         validationReq = {
-            params: { num: '-123.5' },
+            params: {num: '-123.5'},
             query: {
                 flag: 'true',
-                scores: ['1', '2', '100']
+                scores: ['1', '2', '100'],
+                int: '123',
+                decimal: '234.56'
             },
             body: {
                 from: timeStamp.toISOString(),
@@ -43,59 +46,227 @@ describe('Model', function() {
         };
     });
 
-    describe("not specified", function() {
-        it ('should keep original value', function() {
-            var validationModel = {
-                resources: {
-                    num: { isDecimal: true }
-                }
-            };
+    describe('validatorModels', function () {
+        var options = {
+            validatorModels: index.validatorModels,
+            errorsAsArray: true
+        };
 
-            var validationResult = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
-            validationResult.length.should.equal(0);
-            validationReq.params.num.should.equal('-123.5');
+        _.forEach([
+            // Configured validatorModels
+            ['isBoolean', true, 'true', true],
+            ['isDate', true, '2018-03-17', new Date('2018-03-17')],
+            ['isDecimal', true, '123.45', 123.45],
+            ['isDivisibleBy', 5, "10", 10],
+            ['isFloat', true, '123.45', 123.45],
+            ['isInt', true, '-12345', -12345],
+            ['isNatural', true, '12345', 12345],
+            // Without validatorModels
+            ['contains', 'es', 'test'],
+            ['equals', 'test', 'test'],
+            ['is', 'test', 'test'],
+            ['isAfter', '2018-03-17', '2018-03-18'],
+            ['isAlpha', true, 'test'],
+            ['isAlphanumeric', true, 'test123'],
+            ['isBefore', '2018-03-17', '2018-03-16'],
+            ['isCreditCard', true, '4012888888881881'],
+            ['isEmail', true, 'bob@example.com'],
+            ['isHexColor', true, '#aabbcc'],
+            ['isHexadecimal', true, '01234567abcdef'],
+            ['isIP', true, '127.0.0.1'],
+            ['isIPNet', true, '127.0.0.1/27'],
+            ['isIPv4', true, '127.0.0.1'],
+            ['isIPv6', true, '2001:0db8:85a3:0000:0000:8a2e:0370:7334'],
+            ['isIn', ['test'], 'test'],
+            ['isLowercase', true, 'test'],
+            ['isNumeric', true, '12345'],
+            ['isUUID', true, 'bf18cbf6-0cfd-4cc4-8625-a3a150c81e4b'],
+            ['isUUIDv3', true, '6fa459ea-ee8a-3ca4-894e-db77e160355e'],
+            ['isUUIDv4', true, '5d05b396-2ccf-4c6d-bf8b-844191aa3c1b'],
+            ['isUppercase', true, 'TEST'],
+            ['isUrl', true, 'http://example.com'],
+            ['max', 10, '5'],
+            ['min', 1, '5'],
+            ['not', 'test', 'TEST'],
+            ['notContains', 'se', 'test'],
+            ['notIn', ['TEST'], 'test'],
+            ['notRegex', /TEST/, 'test'],
+            ['regex', /test/, 'test']
+
+        ], function (test) {
+            var validator = test[0],
+                conf = test[1],
+                value = test[2],
+                expected = _.isUndefined(test[3]) ? value : test[3];
+            var validatorDescription = ('{ ' + validator + ': ' + JSON.stringify(conf, function(key, val) {
+                return (val instanceof RegExp) ? "REGEX:" + val.toString() : val;
+            }) + ' }').replace(/\"REGEX:(\/.*\/)\"/, "$1");
+            if (value === expected) {
+                it(validatorDescription + ' keeps ' + JSON.stringify(value) + ' unchanged',
+                    testValidator(validator, conf, value, expected));
+            } else {
+                it(validatorDescription + ' maps ' + JSON.stringify(value) + ' to ' + JSON.stringify(expected),
+                    testValidator(validator, conf, value, expected));
+            }
+        });
+
+        function testValidator(validator, conf, value, expected) {
+            return function () {
+                var validationModel = {
+                    queries: {
+                        value: {}
+                    }
+                };
+                validationModel.queries.value[validator] = conf;
+                var req = {
+                    query: {value: value}
+                };
+                var validationResult = index.validation.process(validationModel, req, options);
+                validationResult.length.should.equal(0);
+                req.query.value.should.deepEqual(expected);
+            }
+        }
+    });
+
+    describe('option: validatorModels object', function () {
+        var validationPlugin = index.validationPlugin({
+            errorsAsArray: true,
+            validatorModels: {
+                isDecimal: Number,
+                isBoolean: function (val) {
+                    return val === 'true';
+                }
+            }
+        });
+
+        var validationModel = {
+            queries: {
+                decimal: {isDecimal: true},
+                flag: {isBoolean: true},
+                int: {isInt: true}
+            }
+        };
+
+        it('should apply validatorModels', function () {
+            validationReq.route = {
+                validation: validationModel
+            };
+            validationPlugin(validationReq, {}, function () {
+                validationReq.query.decimal.should.equal(234.56);
+                validationReq.query.flag.should.equal(true);
+                validationReq.query.int.should.equal('123');
+            });
         });
     });
 
-    describe("when validation fails", function() {
-        it ('should keep original value', function() {
+    describe('option: validatorModels array', function () {
+        var validationPlugin = index.validationPlugin({
+            errorsAsArray: true,
+            validatorModels: [{
+                isDecimal: Number
+            }, {
+                isBoolean: function (val) {
+                    return val === 'true';
+                }
+            }]
+        });
+
+        var validationModel = {
+            queries: {
+                decimal: {isDecimal: true},
+                flag: {isBoolean: true},
+                int: {isInt: true}
+            }
+        };
+
+        it('should apply validatorModels', function () {
+            validationReq.route = {
+                validation: validationModel
+            };
+            validationPlugin(validationReq, {}, function () {
+                validationReq.query.decimal.should.equal(234.56);
+                validationReq.query.flag.should.equal(true);
+                validationReq.query.int.should.equal('123');
+            });
+        });
+    });
+
+    describe("not specified", function () {
+        it('if no validatorModels, should keep original value', function () {
             var validationModel = {
                 resources: {
-                    num: { isNatural: true, model: Number }
+                    num: {isDecimal: true}
                 }
             };
 
-            var validationResult = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
+            var validationResult = index.validation.process(validationModel, validationReq, {errorsAsArray: true});
+            validationResult.length.should.equal(0);
+            validationReq.params.num.should.equal('-123.5');
+        });
+
+        it('if validatorModels, should use model', function () {
+            var validationModel = {
+                resources: {
+                    num: {isDecimal: true}
+                }
+            };
+
+            var validationResult = index.validation.process(validationModel, validationReq, {
+                errorsAsArray: true,
+                validatorModels: {isDecimal: Number}
+            });
+            validationResult.length.should.equal(0);
+            validationReq.params.num.should.equal(-123.5);
+        });
+    });
+
+    describe("when validation fails", function () {
+        it('should keep original value', function () {
+            var validationModel = {
+                resources: {
+                    num: {isNatural: true, model: Number}
+                }
+            };
+
+            var validationResult = index.validation.process(validationModel, validationReq, {errorsAsArray: true});
             validationResult.length.should.equal(1);
             validationReq.params.num.should.equal('-123.5');
         });
     });
 
-    describe("when validation passes", function() {
-        it ('should use model value', function() {
+    describe("when validation passes", function () {
+        it('should use model value', function () {
             function DateModel(value) {
                 return new Date(Number(value) || value);
             }
+
             var validationModel = {
                 resources: {
-                    num: { model: Number }
+                    num: {model: Number, isFloat: true}
                 },
                 queries: {
-                    flag: { model: Boolean },
+                    flag: {model: Boolean},
                     scores: {
                         isArray: {
-                            element: { model: Number }
+                            element: {model: Number}
                         }
                     }
                 },
                 content: {
-                    from: { model: DateModel },
-                    to: { model: DateModel },
-                    ts: { model: DateModel }
+                    from: {model: DateModel},
+                    to: {model: DateModel},
+                    ts: {model: DateModel}
                 }
             };
 
-            var validationResult = index.validation.process(validationModel, validationReq, { errorsAsArray: true });
+            var validationResult = index.validation.process(validationModel, validationReq, {
+                errorsAsArray: true,
+                validatorModels: {
+                    isFloat: function () {
+                        throw new Error("Should not be called");
+                    }
+                }
+            });
             validationResult.length.should.equal(0);
             validationReq.params.num.should.equal(-123.5);
             validationReq.query.flag.should.equal(true);


### PR DESCRIPTION
Now that we can specify property models (#72), it would be great to be able to configure restifyValidation to automatically apply a model based on which validator is configured.  That is, if a property uses `{ isInt: true }` validation, its value would be automatically converted to a `number` without having to explicitly specify `{ model: Number }`.

This PR adds a `validatorModels` configuration option and provides standard `validatorModels` for the built-in validators (isBoolean, isDate, isDecimal, isDivisibleBy, isFloat, isInt, isNatural).  The README has more info.

The following example uses `restifyValidation.validatorModels` but then overrides the model for the isDate validator to map values to `moment` rather than to `Date`:
```javascript
var moment = require('moment');
server.use(restifyValidation.validationPlugin({
    validatorModels: [
        restifyValidation.validatorModels,
        { isDate: moment }
    ]
}));
```