### PR TITLE
Add support for isDictionary validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,38 @@ and object with the following attributes:
 }
 ```
 
+### isDictionary
+
+Validates that specified value is a dictionary.  It can take a boolean value or
+an object with the following attributes:
+
+- minLength - minimum number of elements (use with `{ isRequired: true }`)
+- maxLength - maximum number of elements
+- key - validation specification for the dictionary keys
+- value - validation specification for the dictionary values
+
+
+```
+{
+  content: {
+    users: {
+        isDictionary: {
+            minLength: 1,
+            maxLength: 10,
+            key: { isEmail: true },
+            value: {
+                isObject: {
+                    name: { isRequired: true },
+                    phone: { isRequired: true },
+                    year: { isInt: true }
+                }
+            }
+        }
+    }
+  }
+}
+```
+
 ## Conditional validations
 All validation parameters are able to deal with functions as parameters.
 

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -61,17 +61,58 @@ var validators = module.exports = {
                 myValidator.msg = 'Too many elements';
                 return true;
             }
-            if (isArray.element && submittedValue) {
-                return _.reduce(submittedValue, function(previousError, value, index) {
+            if (isArray.element) {
+                return validateCollectionValues(this, submittedValue, isArray.element);
+            }
+        }
+    },
+    isDictionary: function (key, submittedValue, myValidator) {
+        var isDictionary = _.isFunction(myValidator.value) ? myValidator.value.call(this, key, myValidator) : myValidator.value;
+
+        if (!isDictionary) {
+            if (_.isObject(submittedValue) && !_.isArray(submittedValue)) {
+                myValidator.msg = 'Field is an object';
+                return true;
+            }
+        } else if (submittedValue && (!_.isObject(submittedValue) || _.isArray(submittedValue))) {
+            myValidator.msg = 'Field is not object';
+            return true;
+        } else if (submittedValue && _.isObject(isDictionary)) {
+            var keys = _.keys(submittedValue);
+            if (isDictionary.minLength && keys.length < isDictionary.minLength) {
+                myValidator.msg = 'Not enough elements';
+                return true;
+            }
+            if (isDictionary.maxLength && keys.length > isDictionary.maxLength) {
+                myValidator.msg = 'Too many elements';
+                return true;
+            }
+            if (isDictionary.key) {
+                var renamedElements = {};
+                var keyError = _.reduce(submittedValue, function(previousError, value, key) {
                     if (previousError) {
                         return previousError;
                     }
-                    var validateValue = this.validateValue('[' + index + ']', _.constant(value), isArray.element);
-                    if (!validateValue.error) {
-                        submittedValue[index] = validateValue.value;
+                    var validateKey = this.validateValue('(key:' + JSON.stringify(key) + ')', _.constant(key), isDictionary.key);
+                    if (!validateKey.error && key !== String(validateKey.value)) {
+                        // isDictionary.key.model has changed the name of the element
+                        delete submittedValue[key];
+                        renamedElements[validateKey.value] = value;
                     }
-                    return validateValue.error;
+                    return validateKey.error;
+
                 }, false, this);
+                // Merge renamed elements
+                _.extend(submittedValue, renamedElements);
+                if (keyError) {
+                    return keyError;
+                }
+            }
+            if (isDictionary.value) {
+                var valueError =  validateCollectionValues(this, submittedValue, isDictionary.value);
+                if (valueError) {
+                    return valueError;
+                }
             }
         }
     },
@@ -92,6 +133,19 @@ var validators = module.exports = {
         }
     }
 };
+
+function validateCollectionValues(context, collection, validationRules) {
+    return _.reduce(collection, function(previousError, value, index) {
+        if (previousError) {
+            return previousError;
+        }
+        var validateValue = context.validateValue('[' + JSON.stringify(index) + ']', _.constant(value), validationRules);
+        if (!validateValue.error) {
+            collection[index] = validateValue.value;
+        }
+        return validateValue.error;
+    }, false);
+}
 
 
 var notSupported = ['len', 'notNull', 'isNull', 'notEmpty'];

--- a/test/integrations/validator_test.js
+++ b/test/integrations/validator_test.js
@@ -210,6 +210,36 @@ describe('Validators', function () {
         }]]);
     });
 
+    it('isDictionary', function() {
+        test('isDictionary', false, [123, 'string', [123]], [{}, {a: 123}, {a:'string', b:123, c:false}]);
+        test('isDictionary', true, [{}, {a:123}, {a:'string', b:123, c:false}, {a:123, b:'string'}], [123, [123], 'abc']);
+        test('isDictionary', { minLength: 2 }, [{a:1,b:2}, {a:1, b:2, c:3}], [123, {}, {a:123}]);
+        test('isDictionary', { maxLength: 3 }, [{}, {a:1}, {a:1, b:2, c:3}], [123, {a:1,b:2,c:3,d:4}]);
+        test('isDictionary', { key: { isIn: ['a', 'b'] } }, [{}, {a:1}, {a:1, b:2}], [{a:'a',d:'b'}, {c:-1}]);
+        test('isDictionary', { value: { isNatural: true } }, [{}, {a:1}, {a:1, b:2, c:3}], [{a:'a'}, {a:-1}]);
+        var validationModel = {
+            key: { isEmail: true },
+            value: {
+                isObject: {
+                    properties: {
+                        name: { isRequired: true },
+                        age: { isNatural: true, isRequired: false }
+                    }
+                }
+            }
+        };
+        test('isDictionary', validationModel, [{
+            'a@example.com': { name: "Alice" },
+            'b@example.com': { name: "Bob", age: 33 }
+        }], [{
+            'a@example.com': 'a'
+        }, {
+            'a@example.com': { name: "Alice", age: -5 }
+        }, {
+            'not an email': { name: "Bob", age: 33 }
+        }]);
+    });
+
     it('isObject', function() {
         test('isObject', false, [123, 'string', [123]], [{}, {name:"bob"}]);
         test('isObject', true, [{}, {name:"bob"}], [123, 'string', [123]]);

--- a/test/units/model_test.js
+++ b/test/units/model_test.js
@@ -41,7 +41,12 @@ describe('Model', function () {
             body: {
                 from: timeStamp.toISOString(),
                 to: timeStamp.valueOf(),
-                ts: String(timeStamp.valueOf())
+                ts: String(timeStamp.valueOf()),
+                dict: {
+                    'First': 'January',
+                    'Second': 'February',
+                    'Third': 'March'
+                }
             }
         };
     });
@@ -255,9 +260,20 @@ describe('Model', function () {
                 content: {
                     from: {model: DateModel},
                     to: {model: DateModel},
-                    ts: {model: DateModel}
+                    ts: {model: DateModel},
+                    dict: {
+                        isDictionary: {
+                            key: { model: function(s) { return s.toLowerCase(); }},
+                            value: { model: function(s) { return s.toUpperCase(); }}
+                        }
+                    }
                 }
             };
+
+            // Keys should become lower case
+            var expectedDictionaryKeys = _.map(_.keys(validationReq.body.dict), function(s) { return s.toLowerCase(); });
+            // Values should become upper case
+            var expectedDictionaryValues = _.map(_.values(validationReq.body.dict), function(s) { return s.toUpperCase(); });
 
             var validationResult = index.validation.process(validationModel, validationReq, {
                 errorsAsArray: true,
@@ -274,6 +290,8 @@ describe('Model', function () {
             validationReq.body.from.should.deepEqual(timeStamp);
             validationReq.body.to.should.deepEqual(timeStamp);
             validationReq.body.ts.should.deepEqual(timeStamp);
+            _.keys(validationReq.body.dict).should.deepEqual(expectedDictionaryKeys);
+            _.values(validationReq.body.dict).should.deepEqual(expectedDictionaryValues);
         });
     });
 


### PR DESCRIPTION
Validation should support validating content that contains **dictionaries** of data. Unlike with the `isObject` validator, where property names are known in advance and property types are heterogeneous, a dictionary key can be an arbitrary string and the values are usually of the same type.

This PR adds support for an `isDictionary` validator that allows you to validate the number of elements, the format of the key and the type of the values.

Both the key and value validation supports models (see `test/units/model_test.js` for an example).

From the README:

### isDictionary

Validates that specified value is a dictionary.  It can take a boolean value or
an object with the following attributes:

- minLength - minimum number of elements (use with `{ isRequired: true }`)
- maxLength - maximum number of elements
- key - validation specification for the dictionary keys
- value - validation specification for the dictionary values


```
{
  content: {
    users: {
        isDictionary: {
            minLength: 1,
            maxLength: 10,
            key: { isEmail: true },
            value: {
                isObject: {
                    name: { isRequired: true },
                    phone: { isRequired: true },
                    year: { isInt: true }
                }
            }
        }
    }
  }
}
```