### PR TITLE
fix: failing travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,9 @@
 language: node_js
+node_js: 8
+
+install:
+  - nvm install 8
+  - npm install
+
+script:
+  - npm test


### PR DESCRIPTION
Resolves #81 

Travis was defaulting to Node 0.10, which is super old. This updates to use the latest LTS version.